### PR TITLE
Add `DbClosedError`

### DIFF
--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,0 +1,9 @@
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+
+create_exception!(
+    rocksdict,
+    DbClosedError,
+    PyException,
+    "Raised when accessing a closed database instance."
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // #![feature(core_intrinsics)]
 mod encoder;
+mod exceptions;
 mod iter;
 mod options;
 mod rdict;
@@ -8,6 +9,7 @@ mod sst_file_writer;
 mod util;
 mod write_batch;
 
+use crate::exceptions::*;
 use crate::iter::*;
 use crate::options::*;
 use crate::rdict::*;
@@ -104,7 +106,7 @@ use pyo3::prelude::*;
 ///     supports `pickle`.
 ///
 #[pymodule]
-fn rocksdict(_py: Python, m: &PyModule) -> PyResult<()> {
+fn rocksdict(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Rdict>()?;
     m.add_class::<OptionsPy>()?;
     m.add_class::<MemtableFactoryPy>()?;
@@ -140,6 +142,9 @@ fn rocksdict(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<BottommostLevelCompactionPy>()?;
     m.add_class::<ChecksumTypePy>()?;
     m.add_class::<KeyEncodingTypePy>()?;
+
+    m.add("DbClosedError", py.get_type::<DbClosedError>())?;
+
     pyo3_log::init();
     Ok(())
 }

--- a/src/rdict.rs
+++ b/src/rdict.rs
@@ -639,14 +639,14 @@ impl Rdict {
             Some(opt) => opt.clone(),
         };
 
-        Ok(RdictIter::new(
+        RdictIter::new(
             self.get_db()?,
             &self.column_family,
             read_opt,
             &self.loads,
             self.opt_py.raw_mode,
             py,
-        )?)
+        )
     }
 
     /// Iterate through all keys and values pairs.

--- a/test/test_rdict.py
+++ b/test/test_rdict.py
@@ -1,6 +1,6 @@
 import unittest
 from sys import getrefcount
-from rocksdict import Rdict, Options, PlainTableFactoryOptions, SliceTransform, CuckooTableOptions
+from rocksdict import Rdict, Options, PlainTableFactoryOptions, SliceTransform, CuckooTableOptions, DbClosedError
 from random import randint, random, getrandbits
 import os
 import sys
@@ -242,6 +242,9 @@ class TestInt(unittest.TestCase):
 
     def test_reopen(self):
         self.test_dict.close()
+
+        self.assertRaises(DbClosedError, self.test_dict.get("b"))
+
         test_dict = Rdict(self.path, self.opt)
         compare_dicts(self, self.ref_dict, test_dict)
 

--- a/test/test_rdict.py
+++ b/test/test_rdict.py
@@ -243,7 +243,7 @@ class TestInt(unittest.TestCase):
     def test_reopen(self):
         self.test_dict.close()
 
-        self.assertRaises(DbClosedError, self.test_dict.get("b"))
+        self.assertRaises(DbClosedError, lambda: self.test_dict.get(1))
 
         test_dict = Rdict(self.path, self.opt)
         compare_dicts(self, self.ref_dict, test_dict)


### PR DESCRIPTION
This adds a new exception type for when the instance is already closed.

It also cleans up common access patterns to be more succinct:

```rust
let db = self.get_db()?;
```

instead of

```rust
if let Some(db) = &self.db {
   unimplemented!("Some code here")
} else {
    Err(...)
}
```