### PR TITLE
Allow threading on get operations

### DIFF
--- a/src/rdict.rs
+++ b/src/rdict.rs
@@ -1175,7 +1175,7 @@ fn get_batch_inner<'a>(
     for key in key_list {
         keys.push(encode_key(key, raw_mode)?);
     }
-    let values = db.batched_multi_get_cf_opt(cf, &keys, false, read_opt);
+    let values = py.allow_threads(|| db.batched_multi_get_cf_opt(cf, &keys, false, read_opt));
     let result = PyList::empty(py);
     for v in values {
         match v {


### PR DESCRIPTION
Before:

```
Get performance: 4194304 items in 13.99276754213497 seconds
Get performance multi-thread: 4194304 items in 13.610933708958328 seconds
```

After:

```
Get performance: 4194304 items in 14.377041833940893 seconds
Get performance multi-thread: 4194304 items in 5.503023374825716 seconds
```