### PR TITLE
fix RocksDictConfig save not truncating

### DIFF
--- a/src/rdict.rs
+++ b/src/rdict.rs
@@ -120,7 +120,11 @@ impl RocksDictConfig {
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> PyResult<()> {
-        let config_file = fs::File::options().create(true).write(true).open(path)?;
+        let config_file = fs::File::options()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)?;
         match serde_json::to_writer(config_file, self) {
             Ok(_) => Ok(()),
             Err(e) => Err(PyException::new_err(e.to_string())),


### PR DESCRIPTION
As stated by clippy:

if you intend to overwrite an existing file entirely, call `.truncate(true)` if you instead know that you may want to keep some parts of the old file, call `.truncate(false)` alternatively, use `.append(true)` to append to the file instead of overwriting it for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options `#[warn(clippy::suspicious_open_options)]` on by default
