### PR TITLE
Upgrade macos to llvm21, rust to v1.91.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install llvm-20
+      - name: Install llvm-21
         run: |
           brew update
-          brew install llvm@20
+          brew install llvm@21
           brew install lld
       - uses: actions/setup-python@v5
         with:
@@ -28,18 +28,19 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.90.0
+          toolchain: 1.91.1
           default: true
       - name: Build wheels
         run: |
           rustup target add x86_64-apple-darwin
           pip install maturin
           eval "$(brew shellenv)"
+          sed -i.bak 's/^#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1$/#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0/' ${HOMEBREW_PREFIX}/opt/llvm@21/include/c++/v1/__configuration/availability.h
           export MACOSX_DEPLOYMENT_TARGET=10.14
-          export LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@20/lib
-          export CC=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang
-          export CXX=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang++
-          export AR=${HOMEBREW_PREFIX}/opt/llvm@20/bin/llvm-ar
+          export LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@21/lib
+          export CC=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang
+          export CXX=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang++
+          export AR=${HOMEBREW_PREFIX}/opt/llvm@21/bin/llvm-ar
           export CFLAGS="-flto=thin -O3 -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
           export CXXFLAGS="-flto=thin -O3 -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
           export LLD=${HOMEBREW_PREFIX}/opt/lld/bin/ld64.lld
@@ -83,7 +84,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.91.0
+          toolchain: 1.91.1
           default: true
       - name: Build wheels
         uses: messense/maturin-action@v1
@@ -126,7 +127,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2_28
@@ -169,7 +170,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2014
@@ -211,7 +212,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2_28
@@ -253,7 +254,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2014
@@ -291,7 +292,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
@@ -339,7 +340,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install llvm-20
+      - name: Install llvm-21
         run: |
           brew update
-          brew install llvm@20
+          brew install llvm@21
           brew install lld
       - uses: actions/setup-python@v5
         with:
@@ -28,18 +28,19 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.90.0
+          toolchain: 1.91.1
           default: true
       - name: Build wheels
         run: |
           rustup target add x86_64-apple-darwin
           pip install maturin
           eval "$(brew shellenv)"
+          sed -i.bak 's/^#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1$/#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0/' ${HOMEBREW_PREFIX}/opt/llvm@21/include/c++/v1/__configuration/availability.h
           export MACOSX_DEPLOYMENT_TARGET=10.14
-          export LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@20/lib
-          export CC=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang
-          export CXX=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang++
-          export AR=${HOMEBREW_PREFIX}/opt/llvm@20/bin/llvm-ar
+          export LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@21/lib
+          export CC=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang
+          export CXX=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang++
+          export AR=${HOMEBREW_PREFIX}/opt/llvm@21/bin/llvm-ar
           export CFLAGS="-flto=thin -O3 -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
           export CXXFLAGS="-flto=thin -O3 -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
           export LLD=${HOMEBREW_PREFIX}/opt/lld/bin/ld64.lld
@@ -83,7 +84,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.91.0
+          toolchain: 1.91.1
           default: true
       - name: Build wheels
         uses: messense/maturin-action@v1
@@ -126,7 +127,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2_28
@@ -169,7 +170,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2014
@@ -211,7 +212,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2_28
@@ -253,7 +254,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: 2014
@@ -291,7 +292,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
@@ -339,7 +340,7 @@ jobs:
       - name: Build Wheels
         uses: messense/maturin-action@v1
         with:
-          rust-toolchain: 1.91.0
+          rust-toolchain: 1.91.1
           rustup-components: rustfmt
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
         with:
           profile: minimal
-          toolchain: 1.91.0
+          toolchain: 1.91.1
           components: clippy
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "RocksDict"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 description = "Rocksdb Python Binding"
 

--- a/justfile
+++ b/justfile
@@ -4,33 +4,36 @@ clean:
 # for macos
 develop:
     # conda deactivate
-    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@20/lib \
-    CC=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang \
-    CXX=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang++ \
-    AR=${HOMEBREW_PREFIX}/opt/llvm@20/bin/llvm-ar \
+    sed -i.bak 's/^#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1$/#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0/' ${HOMEBREW_PREFIX}/opt/llvm@21/include/c++/v1/__configuration/availability.h
+    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@21/lib \
+    CC=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang \
+    CXX=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang++ \
+    AR=${HOMEBREW_PREFIX}/opt/llvm@21/bin/llvm-ar \
     CFLAGS="-flto=thin -O3 --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" \
     CXXFLAGS="-flto=thin -O3 --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" \
-    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@20/bin/ld64.lld" \
+    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@21/bin/ld64.lld" \
     maturin develop --release --verbose
 
 # for macos
 build:
-    # conda deactivate
-    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@20/lib \
-    CC=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang \
-    CXX=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang++ \
-    AR=${HOMEBREW_PREFIX}/opt/llvm@20/bin/llvm-ar \
+    # conda deactiva
+    sed -i.bak 's/^#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1$/#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0/' ${HOMEBREW_PREFIX}/opt/llvm@21/include/c++/v1/__configuration/availability.h
+    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@21/lib \
+    CC=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang \
+    CXX=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang++ \
+    AR=${HOMEBREW_PREFIX}/opt/llvm@21/bin/llvm-ar \
     CFLAGS="-flto=thin -O3 --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" \
     CXXFLAGS="-flto=thin -O3 --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" \
-    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@20/bin/ld64.lld" \
+    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@21/bin/ld64.lld" \
     maturin build --release --verbose
 
 bin:
-    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@20/lib \
-    CC=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang \
-    CXX=${HOMEBREW_PREFIX}/opt/llvm@20/bin/clang++ \
-    AR=${HOMEBREW_PREFIX}/opt/llvm@20/bin/llvm-ar \
+    sed -i.bak 's/^#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1$/#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0/' ${HOMEBREW_PREFIX}/opt/llvm@21/include/c++/v1/__configuration/availability.h
+    LIBCLANG_PATH=${HOMEBREW_PREFIX}/opt/llvm@21/lib \
+    CC=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang \
+    CXX=${HOMEBREW_PREFIX}/opt/llvm@21/bin/clang++ \
+    AR=${HOMEBREW_PREFIX}/opt/llvm@21/bin/llvm-ar \
     CFLAGS="-flto=thin -O3 --config-system-dir=${HOMEBREW_PREFIX}/etc/clang" \
     CXXFLAGS="-flto=thin -O3 --config-system-dir=${HOMEBREW_PREFIX}/etc/clang" \
-    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@20/bin/ld64.lld" \
+    RUSTFLAGS="-Clinker-plugin-lto -Clinker=$PWD/macos-linker.sh -Clink-arg=-fuse-ld=${HOMEBREW_PREFIX}/opt/lld@21/bin/ld64.lld" \
     cargo build --release --bin create_cf_db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocksdict"
-version = "0.3.28"
+version = "0.3.29"
 description = "Rocksdb Python Binding"
 long_description_content_type = "text/markdown"
 readme = "README.md"


### PR DESCRIPTION
Fix macos v1.91 and llvm21 compatibility issue.

https://github.com/Homebrew/homebrew-core/issues/235411

Currently, changing:
```h
#  define _LIBCPP_INTRODUCED_IN_LLVM_21 1
```
to
```h
#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0
```