### PR TITLE
Do not save rocksdict config when open in read-only modes

### DIFF
--- a/src/rdict.rs
+++ b/src/rdict.rs
@@ -234,7 +234,15 @@ impl Rdict {
             raw_mode: options.raw_mode,
             prefix_extractors: prefix_extractors.clone(),
         };
-        rocksdict_config.save(config_path)?;
+        // if access type is read only, do not save rocksdict config
+        match &access_type.0 {
+            AccessTypeInner::ReadWrite | AccessTypeInner::WithTTL { .. } => {
+                rocksdict_config.save(config_path)?;
+            }
+            _ => {
+                // Skip saving config for ReadOnly and Secondary modes
+            }
+        }
         let opt_inner = &options.inner_opt;
         // define column families
         let cfs = match column_families {


### PR DESCRIPTION
In the current implementation of RocksDict, when opening a Rdict, it will save the RocksDict config file to the directory. However, if that directory is read-only, writing the config file will fail.

Currently the config file is saved to allow further construction of Rdict without need to specify the same config, so skip saving the config file will not affect the main functionality.

So in this PR, we propose to skip saving config if we open Rdict in [read-only modes](https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances) (`ReadOnly` and `Secondary`). This allows us to open a dictionary in a read-only directory.